### PR TITLE
Save tagged registers.

### DIFF
--- a/pk/bits.h
+++ b/pk/bits.h
@@ -22,8 +22,8 @@
 
 #ifdef __riscv64
 # define SLL32    sllw
-# define STORE    sd
-# define LOAD     ld
+# define STORE    sdct
+# define LOAD     ldct
 # define LOG_REGBYTES 3
 #else
 # define SLL32    sll


### PR DESCRIPTION
This is safe as LDCT/SDCT do not check tags in supervisor mode.
Note also that PK won't reuse this memory for userspace, so it
won't break things later.
